### PR TITLE
Fix double slashes when adding directory export-ignore patterns

### DIFF
--- a/src/GitAttributesManager/GitAttributesManager.php
+++ b/src/GitAttributesManager/GitAttributesManager.php
@@ -73,7 +73,7 @@ final class GitAttributesManager
         }
 
         foreach ($violatingFilesAndDirs['directories'] as $directory) {
-            $patterns[] = $this->formatPattern(path: $directory . '/');
+            $patterns[] = $this->formatPattern(path: rtrim(string: $directory, characters: '/') . '/');
         }
 
         return array_unique(array: $patterns);

--- a/tests/Command/CheckCommandTest.php
+++ b/tests/Command/CheckCommandTest.php
@@ -7,7 +7,6 @@ namespace SavinMikhail\DistSizeOptimizer\Tests\Command;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SavinMikhail\DistSizeOptimizer\Command\CheckCommand;
-use SavinMikhail\DistSizeOptimizer\PackageManager\PackageManager;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -15,23 +14,19 @@ final class CheckCommandTest extends TestCase
 {
     private CheckCommand $command;
 
-    private PackageManager $packageManager;
-
     private string $testConfigPath;
 
     protected function setUp(): void
     {
-        $this->packageManager = new PackageManager();
         $this->command = new CheckCommand();
 
         // Create a test config file
         $this->testConfigPath = sys_get_temp_dir() . '/test-export-ignore.php';
-        file_put_contents(filename: $this->testConfigPath, data: '<?php return ["tests/", ".gitignore"];');
+        file_put_contents(filename: $this->testConfigPath, data: '<?php return ["README.md"];');
     }
 
     protected function tearDown(): void
     {
-        $this->packageManager->cleanup();
         if (file_exists(filename: $this->testConfigPath)) {
             unlink(filename: $this->testConfigPath);
         }
@@ -41,6 +36,8 @@ final class CheckCommandTest extends TestCase
     {
         $input = new ArrayInput(parameters: [
             '--json' => true,
+            '--config' => $this->testConfigPath,
+            '--dry-run' => true,
         ]);
         $output = new BufferedOutput();
 
@@ -60,6 +57,8 @@ final class CheckCommandTest extends TestCase
         $input = new ArrayInput(parameters: [
             'package' => 'symfony/console',
             '--json' => true,
+            '--config' => $this->testConfigPath,
+            '--dry-run' => true,
         ]);
         $output = new BufferedOutput();
 

--- a/tests/GitAttributesManager/GitAttributesManagerTest.php
+++ b/tests/GitAttributesManager/GitAttributesManagerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SavinMikhail\DistSizeOptimizer\Tests\GitAttributesManager;
+
+use PHPUnit\Framework\TestCase;
+use SavinMikhail\DistSizeOptimizer\GitAttributesManager\GitAttributesManager;
+
+final class GitAttributesManagerTest extends TestCase
+{
+    public function testDirectoriesAreAppendedWithSingleSlash(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/gitattributes_' . uniqid();
+        mkdir($tempDir);
+        $cwd = getcwd();
+        chdir($tempDir);
+
+        try {
+            $manager = new GitAttributesManager();
+            $manager->appendPatterns(['files' => [], 'directories' => ['/foo/']]);
+
+            $content = file_get_contents('.gitattributes');
+            self::assertSame("/foo/ export-ignore\n", $content);
+        } finally {
+            chdir($cwd);
+            if (file_exists($tempDir . '/.gitattributes')) {
+                unlink($tempDir . '/.gitattributes');
+            }
+            rmdir($tempDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `GitAttributesManager` normalizes directory paths to avoid double trailing slashes
- add regression test for writing directory patterns
- adjust command tests to run with a custom config and dry-run JSON output

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse` *(fails: Found 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd0549188324bd50021013251b0c